### PR TITLE
Remove tag html e php do resultado das buscas

### DIFF
--- a/templates/padraogoverno01/html/com_search/search/default_results.php
+++ b/templates/padraogoverno01/html/com_search/search/default_results.php
@@ -18,10 +18,10 @@ defined('_JEXEC') or die;
 					<span class="hide"><?php echo $this->pagination->limitstart + $result->count.'. ';?></span>
 					<?php if ($result->href) :?>
 						<a href="<?php echo JRoute::_($result->href); ?>"<?php if ($result->browsernav == 1) :?> target="_blank"<?php endif;?>>
-							<?php echo $this->escape($result->title);?>
+							<?php echo $result->title;?>
 						</a>
 					<?php else:?>
-						<?php echo $this->escape($result->title);?>
+						<?php echo $result->title;?>
 					<?php endif; ?>
 		  		</h2>
 		  		<div class="description result-text">

--- a/templates/padraogoverno01/html/com_search/search/default_results.php
+++ b/templates/padraogoverno01/html/com_search/search/default_results.php
@@ -18,10 +18,10 @@ defined('_JEXEC') or die;
 					<span class="hide"><?php echo $this->pagination->limitstart + $result->count.'. ';?></span>
 					<?php if ($result->href) :?>
 						<a href="<?php echo JRoute::_($result->href); ?>"<?php if ($result->browsernav == 1) :?> target="_blank"<?php endif;?>>
-							<?php echo $result->title;?>
+							<?php echo strip_tags($result->title); ?>
 						</a>
 					<?php else:?>
-						<?php echo $result->title;?>
+						<?php echo strip_tags($result->title); ?>
 					<?php endif; ?>
 		  		</h2>
 		  		<div class="description result-text">


### PR DESCRIPTION
No componente de busca o título do resultado aparece como

```L<span class="highlight">724</span>&#160;...```

Com a alteração passa a aparecer corretamente

```L724 ...```